### PR TITLE
docs: add missing docstrings to console and command helpers

### DIFF
--- a/src/repo/cli/commands/new.py
+++ b/src/repo/cli/commands/new.py
@@ -134,6 +134,7 @@ def run_new(args: argparse.Namespace) -> None:
                 )
             else:
                 def print_and_log_auth_command(command: list[str]) -> None:
+                    """Log and print an auth command issued by the GitHub auth helper."""
                     log_command(logger, command, dry_run=args.dry_run)
                     print(f"\n{ansi.grey}{' '.join(command)}{ansi.reset}")
 

--- a/src/repo/cli/commands/started.py
+++ b/src/repo/cli/commands/started.py
@@ -140,6 +140,7 @@ def run_started(args: argparse.Namespace) -> None:
                 )
             else:
                 def print_and_log_auth_command(command: list[str]) -> None:
+                    """Log and print an auth command issued by the GitHub auth helper."""
                     log_command(logger, command, dry_run=args.dry_run)
                     print(f"\n{ansi.grey}{' '.join(command)}{ansi.reset}")
 

--- a/src/repo/cli/console/ansi.py
+++ b/src/repo/cli/console/ansi.py
@@ -23,6 +23,7 @@ __all__ = sorted(list[str](_ALIASES.keys()) + list[str](_CODES.keys()))
 
 
 def __getattr__(name: str) -> str:
+    """Return the ANSI escape code for a lowercase colour alias."""
     alias = _ALIASES.get(name)
     if alias is None:
         raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
@@ -30,4 +31,5 @@ def __getattr__(name: str) -> str:
 
 
 def __dir__() -> list[str]:
+    """Return all public names, including uppercase codes and lowercase aliases."""
     return sorted(list[str](globals().keys()) + list[str](_ALIASES.keys()))

--- a/src/repo/cli/console/helpfmt.py
+++ b/src/repo/cli/console/helpfmt.py
@@ -10,15 +10,18 @@ class ColoredHelpFormatter(argparse.RawDescriptionHelpFormatter):
     """HelpFormatter that adds colour to key parts of the help output."""
 
     def start_section(self, heading: str) -> None:  # type: ignore[override]
+        """Start a new help section with a green-coloured heading."""
         coloured_heading = f"{ansi.green}{heading}{ansi.RESET}"
         super().start_section(coloured_heading)
 
     def add_usage(self, usage, actions, groups, prefix=None):
+        """Add the usage line with a green 'usage:' prefix."""
         if prefix is None:
             prefix = f"{ansi.green}usage:{ansi.RESET} "
         super().add_usage(usage, actions, groups, prefix)
 
     def _format_action_invocation(self, action: argparse.Action) -> str:
+        """Format option flags in cyan and append a grey metavar when applicable."""
         if not action.option_strings:
             return super()._format_action_invocation(action)
 
@@ -30,6 +33,7 @@ class ColoredHelpFormatter(argparse.RawDescriptionHelpFormatter):
         return ", ".join(parts)
 
     def _format_args(self, action, default_metavar):
+        """Wrap the metavar text in grey ANSI codes."""
         text = super()._format_args(action, default_metavar)
         return f"{ansi.grey}{text}{ansi.RESET}"
 

--- a/src/repo/cli/console/progress.py
+++ b/src/repo/cli/console/progress.py
@@ -15,6 +15,7 @@ class Spinner:
     """A simple terminal spinner."""
 
     def __init__(self, message: str = "") -> None:
+        """Initialize the spinner with an optional status message."""
         self.message = message
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None


### PR DESCRIPTION
## Summary
- Add docstring to `Spinner.__init__` in `console/progress.py`
- Add docstrings to module-level `__getattr__` and `__dir__` in `console/ansi.py`
- Add docstrings to `start_section`, `add_usage`, `_format_action_invocation`, and `_format_args` in `console/helpfmt.py`
- Add docstrings to the nested `print_and_log_auth_command` callback in both `commands/new.py` and `commands/started.py`

## Test plan
- [ ] Verify no existing tests break (`pytest` / `make test`)
- [ ] Confirm docstrings appear correctly via `help()` in a Python REPL

🤖 Generated with [Claude Code](https://claude.com/claude-code)